### PR TITLE
Unified Random Number Generator

### DIFF
--- a/megastep/core.py
+++ b/megastep/core.py
@@ -32,7 +32,7 @@ def _init_agents(n_envs, n_agents, device='cuda'):
 
 class Core: 
 
-    def __init__(self, scenery, res=64, fov=130, fps=10):
+    def __init__(self, scenery, res=64, fov=130, fps=10, rng=np.random.default_rng()):
         """The core rendering and physics interface. 
 
         To create the Core, you pass a :class:`~megastep.cuda.Scenery` that describes the environment. Once created, 
@@ -50,7 +50,7 @@ class Core:
         :var fov: The field of view in degrees.
         :var agent_radius: The radius of a disc containing the agent, in meters.
         :var fps: The framerate.
-        :var random: The seeded :class:`numpy.random.RandomState` used to initialize the environment. By reusing this
+        :var rng: The seeded :func:`numpy.random.default_rng` used to initialize the environment. By reusing this generator
             in any extra random decisions made when generating the environments, it can be guaranteed you'll get the same
             environments every time.
 
@@ -76,7 +76,7 @@ class Core:
         # TODO: Make this adjustable
         self.agent_radius = AGENT_RADIUS
         self.fps = fps
-        self.random = np.random.RandomState(1)
+        self.rng = rng
 
         # TODO: This needs to be propagated to the C++ side
         self.device = scenery.model.device

--- a/megastep/core.py
+++ b/megastep/core.py
@@ -32,7 +32,7 @@ def _init_agents(n_envs, n_agents, device='cuda'):
 
 class Core: 
 
-    def __init__(self, scenery, res=64, fov=130, fps=10, rng=np.random.default_rng()):
+    def __init__(self, scenery, res=64, fov=130, fps=10, rng=np.random.default_rng(), **kwargs):
         """The core rendering and physics interface. 
 
         To create the Core, you pass a :class:`~megastep.cuda.Scenery` that describes the environment. Once created, 

--- a/megastep/cubicasa.py
+++ b/megastep/cubicasa.py
@@ -174,7 +174,7 @@ def geometry_data(regenerate=False):
     return unflatten(flat)
 
 _cache = None
-def sample(n_geometries, split='training', rng=np.random.default_rng()):
+def sample(n_geometries, split='training', rng=np.random.default_rng(), **kwargs):
     """Returns a random sample of cubicasa :ref:`geometries <geometry>`. 
 
     If you pass the same arguments, you'll get the same sample every time.

--- a/megastep/cubicasa.py
+++ b/megastep/cubicasa.py
@@ -174,7 +174,7 @@ def geometry_data(regenerate=False):
     return unflatten(flat)
 
 _cache = None
-def sample(n_geometries, split='training', seed=1):
+def sample(n_geometries, split='training', rng=np.random.default_rng()):
     """Returns a random sample of cubicasa :ref:`geometries <geometry>`. 
 
     If you pass the same arguments, you'll get the same sample every time.
@@ -199,7 +199,7 @@ def sample(n_geometries, split='training', seed=1):
     :param split: Whether to return a sample from the ``training`` set, the ``test`` set, or ``all`` . The split is
         90/10 in favour of the training set. Defaults to ``training`` . 
     :type split: str
-    :param seed: The seed to use when allocating the training and test sets.
+    :param rng: The random number generator to use when allocating the training and test sets.
 
     :return: A list of geometries.
     """
@@ -211,7 +211,7 @@ def sample(n_geometries, split='training', seed=1):
         _cache = type(_cache)({k: type(v)({'id': k, **v}) for k, v in _cache.items()})
     
     cutoff = int(.9*len(_cache))
-    order = np.random.RandomState(seed).permutation(sorted(_cache))
+    order = rng.permutation(sorted(_cache))
     if split == 'training':
         order = order[:cutoff]
     elif split == 'test':

--- a/megastep/modules.py
+++ b/megastep/modules.py
@@ -305,7 +305,7 @@ class RandomSpawns:
         """
         self.core = core
 
-        positions = random_empty_positions(geometries, core.n_agents, n_spawns)
+        positions = random_empty_positions(geometries, core.n_agents, n_spawns, rng=core.rng)
         angles = core.rng.uniform(-180, +180, (len(geometries), core.n_agents, n_spawns))
         self._spawns = arrdict.torchify(arrdict.arrdict(positions=positions, angles=angles)).to(core.device)
 

--- a/megastep/modules.py
+++ b/megastep/modules.py
@@ -269,7 +269,7 @@ class IMU:
             self.core.agents.angvelocity[..., None]/self.ang_scale,
             to_local_frame(self.core.agents.angles, self.core.agents.velocity)/self.speed_scale], -1)
 
-def random_empty_positions(geometries, n_agents, n_points):
+def random_empty_positions(geometries, n_agents, n_points, rng=np.random.default_rng()):
     """Returns a tensor of randomly-selected empty points in each :ref:`geometry <geometry>`.
     
     The returned tensor is a (n_geometries, n_agents, n_points, 2)-float tensor, with the coordinates given in meters.
@@ -284,11 +284,11 @@ def random_empty_positions(geometries, n_agents, n_points):
 
         # There might be fewer open points than we're asking for
         n_possible = min(len(sample)//n_agents, n_points)
-        sample = sample[np.random.choice(np.arange(len(sample)), (n_possible, n_agents), replace=True)]
+        sample = sample[rng.choice(np.arange(len(sample)), (n_possible, n_agents), replace=True)]
 
         # So repeat the sample until we've got enough
         sample = np.concatenate([sample]*int(n_points/len(sample)+1))[-n_points:]
-        sample = np.random.permutation(sample)
+        sample = rng.permutation(sample)
         points.append(geometry.centers(sample, g.masks.shape, g.res).transpose(1, 0, 2))
     return arrdict.stack(points)
         
@@ -306,7 +306,7 @@ class RandomSpawns:
         self.core = core
 
         positions = random_empty_positions(geometries, core.n_agents, n_spawns)
-        angles = core.random.uniform(-180, +180, (len(geometries), core.n_agents, n_spawns))
+        angles = core.rng.uniform(-180, +180, (len(geometries), core.n_agents, n_spawns))
         self._spawns = arrdict.torchify(arrdict.arrdict(positions=positions, angles=angles)).to(core.device)
 
     def __call__(self, reset):

--- a/megastep/scene.py
+++ b/megastep/scene.py
@@ -40,14 +40,14 @@ def agent_colors():
 def resolutions(lines):
     return np.ceil(lengths(lines)/core.TEXTURE_RES).astype(int)
 
-def wall_pattern(n, l=.5, random=np.random):
+def wall_pattern(n, l=.5, rng=np.random.default_rng()):
     p = core.TEXTURE_RES/l
-    jumps = random.choice(np.array([0., 1.]), p=np.array([1-p, p]), size=n)
-    jumps = jumps*random.normal(size=n)
+    jumps = rng.choice(np.array([0., 1.]), p=np.array([1-p, p]), size=n)
+    jumps = jumps*rng.normal(size=n)
     value = .5 + .5*(jumps.cumsum() % 1)
     return value
 
-def init_textures(agentlines, agentcolors, walls, random=np.random):
+def init_textures(agentlines, agentcolors, walls, rng=np.random.default_rng()):
     colormap = np.array([mpl.colors.to_rgb(c) for c in COLORS])
     wallcolors = colormap[np.arange(len(walls)) % len(colormap)]
     colors = np.concatenate([agentcolors, wallcolors])
@@ -61,19 +61,19 @@ def init_textures(agentlines, agentcolors, walls, random=np.random):
     textures = core.gamma_decode(colors[indices])
 
     # Gives walls an even pattern that makes depth perception easy
-    pattern = wall_pattern(textures.shape[0], random=random)
+    pattern = wall_pattern(textures.shape[0], rng=rng)
     pattern[:sum(texwidths[:len(agentlines)])] = 1.
     textures = textures*pattern[:, None]
 
     return textures, texwidths
 
-def random_lights(lights, random=np.random):
+def random_lights(lights, rng=np.random.default_rng()):
     return np.concatenate([
         lights,
-        random.uniform(.5, 2., (len(lights), 1))], -1)
+        rng.uniform(.5, 2., (len(lights), 1))], -1)
 
 @torch.no_grad()
-def scenery(geometries, n_agents=1, device='cuda', random=np.random): 
+def scenery(geometries, n_agents=1, device='cuda', rng=np.random.default_rng()):
     agentlines = np.tile(agent_model(), (n_agents, 1, 1))
     agentcolors = np.tile(agent_colors(), (n_agents, 1))
 
@@ -81,7 +81,7 @@ def scenery(geometries, n_agents=1, device='cuda', random=np.random):
     for g in geometries:
         lights = random_lights(g.lights)
         lines = np.concatenate([agentlines, g.walls])
-        textures, texwidths = init_textures(agentlines, agentcolors, g.walls, random) 
+        textures, texwidths = init_textures(agentlines, agentcolors, g.walls, rng)
         data.append(arrdict.arrdict(
             lights=arrdict.arrdict(vals=lights, widths=len(lights)),
             lines=arrdict.arrdict(vals=lines, widths=len(lines)),

--- a/megastep/scene.py
+++ b/megastep/scene.py
@@ -79,7 +79,7 @@ def scenery(geometries, n_agents=1, device='cuda', rng=np.random.default_rng()):
 
     data = []
     for g in geometries:
-        lights = random_lights(g.lights)
+        lights = random_lights(g.lights, rng)
         lines = np.concatenate([agentlines, g.walls])
         textures, texwidths = init_textures(agentlines, agentcolors, g.walls, rng)
         data.append(arrdict.arrdict(

--- a/rebar/fsm.py
+++ b/rebar/fsm.py
@@ -274,17 +274,16 @@ def MatchCoin():
         .build())
 
 @fsm
-def RandomChain(n=2, seed=0):
+def RandomChain(n=2, rng=np.random.default_rng()):
     assert n >= 2, 'Need the radius to be at least 2'
     b = Builder()
-    random = np.random.RandomState(seed)
-    actions = random.permutation([0, 1])
+    actions = rng.permutation([0, 1])
     (b.state(0, obs=0., start=1.)
         .to(0, action=actions[0])
         .to(1, action=actions[1]))
     for i in range(1, n):
         reward = (i == n-1)
-        actions = random.permutation([0, 1])
+        actions = rng.permutation([0, 1])
         (b.state(+i, obs=+i/n)
             .to(0, action=actions[0])
             .to(i+1, action=actions[1], reward=+reward))


### PR DESCRIPTION
[**NEP 19 — Random number generator policy**](https://numpy.org/neps/nep-0019-rng-policy.html) states that regarding [`numpy.random.*`](https://numpy.org/neps/nep-0019-rng-policy.html#numpy-random) "[the] preferred best practice for getting reproducible pseudorandom numbers is to instantiate a generator object with a seed and pass it around". According to this, the currently used global `RandomState` in numpy can cause problems. Therefore, this pull request proposes replaces it using the numpy random number generators instead.

With this pull request, a random number generator (`rng`) object can be passed to the `core` (with a new `default_rng` generator object as the default argument). It also adds the same argument to the `sample` function in `cubicasa.py`, to the `RandomSpawns` class and the `random_empty_positions` function in `modules.py`, the `RandomChain` function in `fsm.py`, and the `init_textures`, `wall_pattern`, `random_lights`, `scenery` functions in `scene.py`.

In the `RandomSpawns` class (`modules.py`), the core `rng` is automatically passed to the `random_empty_positions` during initialization. Likewise, the `rng` object is passed from `scenery` to `random_lights` and `init_textures`, and from `init_textures` to `wall_pattern`.

This way, during environment setup, one can create a single (potentially seeded) `rng` generator object to pass to all subsequent use cases. 