### PR TITLE
Fix deprecation warnings introduced in PyTorch version >=1.10

### DIFF
--- a/megastep/demo/lstm.py
+++ b/megastep/demo/lstm.py
@@ -54,7 +54,7 @@ class Packer:
     def unpack_state(self, hp):
         T, B = self._reset.shape
         mask = (self._order % T == T-1)
-        left_idxs = (self._order//T)[mask]
+        left_idxs = (torch.div(self._order,T,rounding_mode='floor'))[mask]
         right_idxs = self._b[self._order][mask]
 
         h = hp.new_zeros((1, B, *hp.shape[2:]))

--- a/megastep/src/common.h
+++ b/megastep/src/common.h
@@ -89,7 +89,7 @@ struct RaggedPackedTensorAccessor {
 TT inverses(const TT& widths);
 #else
 TT inverses(const TT& widths) {
-    at::AutoNonVariableTypeMode nonvar{true};
+    c10::InferenceMode nonvar{true};
     const auto starts = widths.cumsum(0) - widths.to(at::kLong);
     const auto flags = at::ones(starts.size(0), at::dtype(at::kInt).device(widths.device()));
     auto indices = at::zeros(widths.sum(0).item<int64_t>(), at::dtype(at::kInt).device(widths.device()));

--- a/megastep/src/kernels.cu
+++ b/megastep/src/kernels.cu
@@ -220,7 +220,7 @@ __host__ Physics physics(const Scenery& scenery, const Agents& agents) {
         A*F, agents.positions.pta(), agents.velocity.pta(), scenery.lines.pta(), progress.pta());
 
     //TODO: Collisions should only kill the normal component of momentum
-    at::AutoNonVariableTypeMode nonvar{true};
+    c10::InferenceMode nonvar{true};
     agents.positions.t.set_(agents.positions.t + progress.t.unsqueeze(-1)*agents.velocity.t/FPS);
     agents.velocity.t.masked_fill_(progress.t.unsqueeze(-1) < 1, 0.f);
     agents.angles.t.set_(normalize_degrees(agents.angles.t + progress.t*agents.angvelocity.t/FPS));


### PR DESCRIPTION
Using megastep with PyTorch 1.10 introduces 2 deprecation warnings, which could lead to errors in future PyTorch versions.
Consequently, this pull request fixes the issues applying the officially recommended alternatives:

1. The PyTorch `torch.floor_divide` function used by a tensor's `__floordiv__` method and thus also invoked by the `//` operator is deprecated. In megastep, it is used in `demo/lstm.py` (l. 57) and has been replaced applying the [official recommendation](https://pytorch.org/docs/1.10/generated/torch.floor_divide.html?highlight=floor_divide#torch.floor_divide) by using use `torch.div()` with `rounding_mode='floor'`.
2. The `AutoNonVariableTypeMode` used in kernels.cu and corresponding header is deprecated. The [migration guide](https://pytorch.org/cppdocs/notes/inference_mode.html#migration-guide-from-autononvariabletypemode) recommends replacing it with `c10::InferenceMode`.